### PR TITLE
updated requirements.txt to new versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 scipy
 faker
-git+https://github.com/neurophysik/jitcdde.git@697fb23#egg=jitcdde
-git+https://github.com/TimeSynth/TimeSynth.git
+git+https://github.com/neurophysik/jitcdde.git@0.32#egg=jitcdde
+git+https://github.com/TimeSynth/TimeSynth.git@4c096cb


### PR DESCRIPTION
jitcdde & timesynth had some updates to support python3 so i had to adjust the requirements.txt to make things work. At least, i think it works.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
